### PR TITLE
feat: rfc 1071 - internet checksum

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,1 @@
-pub fn add(left: u64, right: u64) -> u64 {
-    left + right
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}
+pub mod rfc1071;

--- a/src/rfc1071/mod.rs
+++ b/src/rfc1071/mod.rs
@@ -1,0 +1,63 @@
+pub fn internet_checksum(data: &[u8]) -> u16 {
+    let mut sum: u32 = 0;
+
+    let chunks = data.chunks_exact(2);
+    let remainder = chunks.remainder();
+
+    for chunk in chunks {
+        let word = u16::from_be_bytes([chunk[0], chunk[1]]) as u32;
+        sum += word;
+    }
+
+    if !remainder.is_empty() {
+        sum += (remainder[0] as u32) << 8;
+    }
+
+    sum = (sum & 0xFFFF) + (sum >> 16);
+    sum = (sum & 0xFFFF) + (sum >> 16);
+
+    !(sum as u16)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_internet_checksum() {
+        let data: [u8; 20] = [
+            0x45, 0x00, 0x00, 0x73, 0x00, 0x00, 0x40, 0x00, 0x40, 0x11, 0x00, 0x00, 0xc0, 0xa8,
+            0x00, 0x01, 0xc0, 0xa8, 0x00, 0xc7,
+        ];
+        let checksum = internet_checksum(&data);
+        assert_eq!(checksum, 0xb861);
+    }
+
+    #[test]
+    fn test_empty_data() {
+        let data: [u8; 0] = [];
+        let checksum = internet_checksum(&data);
+        assert_eq!(checksum, 0xFFFF);
+    }
+
+    #[test]
+    fn test_single_byte() {
+        let data = [0x42];
+        let checksum = internet_checksum(&data);
+        assert_eq!(checksum, !0x4200);
+    }
+
+    #[test]
+    fn test_odd_length() {
+        let data = [0x12, 0x34, 0x56];
+        let checksum = internet_checksum(&data);
+        assert_eq!(checksum, !(0x1234 + 0x5600));
+    }
+
+    #[test]
+    fn test_carry_propagation() {
+        let data = [0xFF, 0xFF, 0xFF, 0xFF];
+        let checksum = internet_checksum(&data);
+        assert_eq!(checksum, 0);
+    }
+}


### PR DESCRIPTION
Implements RFC 1071 internet checksum algorithm with comprehensive test coverage.

## Changes
- Added  module with internet checksum implementation
- Follows RFC 1071 specification for checksum calculation
- Handles odd-length data by padding with zero
- Includes proper carry propagation

## Tests
- Empty data handling
- Single byte checksums
- Odd-length data
- Carry propagation edge cases

Resolves the need for RFC 1071 checksum functionality in the codebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added RFC 1071 Internet checksum capability for computing checksums over byte data.
- Refactor
  - Updated the public API to expose a dedicated checksum module, replacing the previous placeholder utility.
  - Note: This alters the exposed interface and may require minor updates in downstream usages.
- Tests
  - Added comprehensive test coverage for checksum behavior, including empty, odd-length, and carry-propagation cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->